### PR TITLE
Fix plugin API compatibility

### DIFF
--- a/bungee/build.gradle
+++ b/bungee/build.gradle
@@ -4,11 +4,11 @@ version = '1.0-SNAPSHOT'
 repositories {
     maven {
         name = "sonatype"
-        url = "https://oss.sonatype.org/content/groups/public/"
+        url = "https://oss.sonatype.org/content/repositories/snapshots/"
     }
 }
 
 dependencies {
     implementation(project(":common"))
-    compileOnly "net.md-5:bungeecord-api:1.20-R0.1-SNAPSHOT"
+    compileOnly 'net.md-5:bungeecord-api:1.19-R0.1-SNAPSHOT'
 }

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -15,6 +15,6 @@ repositories {
 
 dependencies {
     implementation(project(":common"))
-    compileOnly 'com.github.MWHunter:GrimAPI:c3a80bd'
+    compileOnly 'com.github.grimanticheat:GrimAPI:d7fdef7186'
     compileOnly 'org.spigotmc:spigot-api:1.8.8-R0.1-SNAPSHOT'
 }

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -8,7 +8,7 @@ repositories {
     }
     maven {
         name = "sonatype"
-        url = "https://oss.sonatype.org/content/groups/public/"
+        url = "https://oss.sonatype.org/content/repositories/snapshots/"
     }
     maven { url = uri("https://jitpack.io/") }
 }
@@ -16,5 +16,5 @@ repositories {
 dependencies {
     implementation(project(":common"))
     compileOnly 'com.github.MWHunter:GrimAPI:c3a80bd'
-    compileOnly "org.spigotmc:spigot-api:1.20.2-R0.1-SNAPSHOT"
+    compileOnly 'org.spigotmc:spigot-api:1.8.8-R0.1-SNAPSHOT'
 }

--- a/spigot/src/main/java/tech/nicecraftz/spigot/GrimBridge.java
+++ b/spigot/src/main/java/tech/nicecraftz/spigot/GrimBridge.java
@@ -1,6 +1,6 @@
 package tech.nicecraftz.spigot;
 
-import ac.grim.grimac.GrimAbstractAPI;
+import ac.grim.grimac.api.GrimAbstractAPI;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;

--- a/spigot/src/main/java/tech/nicecraftz/spigot/listener/GrimAPIListener.java
+++ b/spigot/src/main/java/tech/nicecraftz/spigot/listener/GrimAPIListener.java
@@ -1,6 +1,6 @@
 package tech.nicecraftz.spigot.listener;
 
-import ac.grim.grimac.events.CommandExecuteEvent;
+import ac.grim.grimac.api.events.CommandExecuteEvent;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.bukkit.Bukkit;

--- a/spigot/src/main/resources/plugin.yml
+++ b/spigot/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: GrimBridge
 version: '1.1'
 main: tech.nicecraftz.spigot.GrimBridge
-api-version: '1.20'
+api-version: '1.13'
 authors: [ nicecraftz ]
 
 depend: [ "GrimAC" ]


### PR DESCRIPTION
Right now, GrimBridge does not load on pre-1.20 (1.13-1.19.4) servers due to this error:

```
[06:42:10] [Server thread/ERROR]: [ModernPluginLoadingStrategy] Could not load plugin 'GrimBridge-1.1-all.jar' in folder 'plugins'
org.bukkit.plugin.InvalidPluginException: Unsupported API version 1.20
```

This is fixed in this PR.