### PR TITLE
Fix grimapi dependency

### DIFF
--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -15,6 +15,6 @@ repositories {
 
 dependencies {
     implementation(project(":common"))
-    compileOnly 'com.github.grimanticheat:GrimAPI:d7fdef7186'
+    compileOnly 'com.github.grimanticheat:grimapi:05e31d62f2'
     compileOnly 'org.spigotmc:spigot-api:1.8.8-R0.1-SNAPSHOT'
 }


### PR DESCRIPTION
This fixes compiling error due to the grimapi dependency missing.

Note: Grim has a platform independence branch that refactors the event system. Once this is merged, GrimBridge will no longer work.